### PR TITLE
Allow railties 5

### DIFF
--- a/phaser-rails.gemspec
+++ b/phaser-rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["{lib,vendor}/**/*"] + ['README.md']
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'railties', '~> 4.0'
+  spec.add_dependency 'railties', '>= 4.0'
 
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake', '~> 0.8'


### PR DESCRIPTION
Not sure what is the extent of the changes in Rails5 on railties, but this allow me to integrate the latest version of phaser as opposed to be stuck with `phaser-rails (2.0.5.0)`

Thought I would share it. With action cables, this might get popular real fast.
